### PR TITLE
Fix bottom bar message overflowing

### DIFF
--- a/src/common/styles/component-bottom-bar.css
+++ b/src/common/styles/component-bottom-bar.css
@@ -1,6 +1,7 @@
 .bottom-bar-message {
     font-size: 16px;
     flex: 1;
+    min-width: 0;
 }
 
 .bottom-bar-message span.long-text {


### PR DESCRIPTION
This fixes issue #1 where the bottom bar message overflows and pushes
the play/stop button out of the viewport, which makes the user unable
to start/stop the playback.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/innovate-technologies/player/5)
<!-- Reviewable:end -->
